### PR TITLE
Updated the simple_pool to safely pop from the deque with minimal copy.

### DIFF
--- a/src/periodic_worker.hpp
+++ b/src/periodic_worker.hpp
@@ -102,7 +102,7 @@ namespace siddiqsoft
         /// with compiler error when the client application includes any of the windows headers! Disabled for now.
         nlohmann::json toJson() const
         {
-            return {{"_typver", "siddiqsoft.asynchrony-lib.periodic_worker/0.9"},
+            return {{"_typver", "siddiqsoft.asynchrony-lib.periodic_worker/0.10"},
                     {"invokeCounter", invokeCounter},
                     {"threadPriority", Pri},
                     {"waitInterval", invokePeriod.count()}};

--- a/src/roundrobin_pool.hpp
+++ b/src/roundrobin_pool.hpp
@@ -94,7 +94,7 @@ namespace siddiqsoft
         /// @param  this object
         nlohmann::json toJson() const
         {
-            return {{"_typver", "siddiqsoft.asynchrony-lib.roundrobin_pool/0.9"},
+            return {{"_typver", "siddiqsoft.asynchrony-lib.roundrobin_pool/0.10"},
                     {"workersSize", workersSize},
                     {"queueCounter", queueCounter.load()}};
         }


### PR DESCRIPTION
Fixed the simple_pool to use the same logic in simple_worker to pop the item from the deque and use optional getNextItem fro deque.

Prior to change, the new `test3` resulted in the following warnings:

```cpp
1>C:\Users\maas\source\repos\siddiqsoft\asynchrony-lib\src\simple_pool.hpp(100,39): error C2512: 'cat_type': no appropriate default constructor available
1>C:\Users\maas\source\repos\siddiqsoft\asynchrony-lib\tests\simple_pool.cpp(140,8): message : see declaration of 'cat_type'
1>C:\Users\maas\source\repos\siddiqsoft\asynchrony-lib\src\simple_pool.hpp(81): message : while compiling class template member function 'siddiqsoft::simple_pool<cat_type,0>::simple_pool(std::function<void (T &)>)'
1>        with
1>        [
1>            T=cat_type
1>        ]
1>C:\Users\maas\source\repos\siddiqsoft\asynchrony-lib\tests\simple_pool.cpp(157): message : see reference to function template instantiation 'siddiqsoft::simple_pool<cat_type,0>::simple_pool(std::function<void (T &)>)' being compiled
1>        with
1>        [
1>            T=cat_type
1>        ]
1>C:\Users\maas\source\repos\siddiqsoft\asynchrony-lib\tests\simple_pool.cpp(157): message : see reference to class template instantiation 'siddiqsoft::simple_pool<cat_type,0>' being compiled
1>C:\Users\maas\source\repos\siddiqsoft\asynchrony-lib\src\simple_pool.hpp(104,46): error C2280: 'cat_type &cat_type::operator =(const cat_type &)': attempting to reference a deleted function
1>C:\Users\maas\source\repos\siddiqsoft\asynchrony-lib\tests\simple_pool.cpp(149): message : compiler has generated 'cat_type::operator =' here
1>C:\Users\maas\source\repos\siddiqsoft\asynchrony-lib\tests\simple_pool.cpp(149,1): message : 'cat_type &cat_type::operator =(const cat_type &)': function was implicitly deleted because a data member invokes a deleted or inaccessible function 'meow_type &meow_type::operator =(const meow_type &)'
1>C:\Users\maas\source\repos\siddiqsoft\asynchrony-lib\tests\simple_pool.cpp(137,1): message : 'meow_type &meow_type::operator =(const meow_type &)': function was implicitly deleted because 'meow_type' has a user-defined move constructor
```